### PR TITLE
ReCaptcha v2 API Examples/iMacros Example/ReCaptcha_solver.iim

### DIFF
--- a/ReCaptcha v2 API Examples/iMacros Example/ReCaptcha_solver.iim
+++ b/ReCaptcha v2 API Examples/iMacros Example/ReCaptcha_solver.iim
@@ -7,7 +7,7 @@ SET !EXTRACT_TEST_POPUP NO
 SET !ERRORIGNORE YES
 SET !TIMEOUT_PAGE 1
 'SET !TIMEOUT_STEP 1
-URL GOTO=javascript:((function(){var%20a=window.content.document.getElementsByTagName('iframe');%20%20var%20k='';%20%20for(var%20x=0;x<a.length;x++)%20%20{%20%20%20if(a[x].src.includes('https://www.google.com/recaptcha/api2/anchor?k'))%20%20%20{%20%20%20%20k=a[x].src.split('?k=')[1].split('&')[0];%20%20%20%20a[x].setAttribute("name","I0_myownid");%20%20%20%20window.content.document.getElementById('g-recaptcha-response').style.display='';%20%20%20%20break;%20%20%20}%20%20}%20%20window.content.document.getElementById('g-recaptcha-response').textContent=k;}))();
+URL GOTO=javascript:((function(){var%20a=window.content.document.getElementsByTagName('iframe');%20%20var%20k='';%20%20for(var%20x=0;x<a.length;x++)%20%20{%20%20%20if(a[x].src.includes('https://www.google.com/recaptcha/api2/anchor?k'))%20%20%20{%20%20%20%20k=a[x].src.split('?k=')[1].split('&')[0];%20%20%20%20a[x].setAttribute("name","I0_myownid");%20%20%20%20window.content.document.getElementById('g-recaptcha-response').style.display='';%20%20%20%20break;%20%20%20}%20%20}%20%20window.content.document.getElementById('g-recaptcha-response').textContent='';}))();
 SET !TIMEOUT_PAGE 60
 TAG POS=1 TYPE=TEXTAREA FORM=ID:* ATTR=ID:g-recaptcha-response EXTRACT=TXT
 SET k {{!EXTRACT}}


### PR DESCRIPTION
On line 10, g-recaptcha-response textarea is set to your googlekey when filling the form which causes problems.
Sometimes, both the googlekey and g-recaptcha-response will be sent at the same time and make the test fail.
Setting the textarea to '' instead of your googlekey avoids a lot of failures.