### PR TITLE
remove useless proxy parameter from API calls

### DIFF
--- a/ReCaptcha v2 API Examples/Python Example/2captcha_python_api_example.py
+++ b/ReCaptcha v2 API Examples/Python Example/2captcha_python_api_example.py
@@ -5,30 +5,30 @@ from time import sleep
 API_KEY = ''  # Your 2captcha API KEY
 site_key = ''  # site-key, read the 2captcha docs on how to get this
 url = 'http://somewebsite.com'  # example url
-proxy = '127.0.0.1:6969'  # example proxy
-
-proxy = {'http': 'http://' + proxy, 'https': 'https://' + proxy}
 
 s = requests.Session()
 
 # here we post site key to 2captcha to get captcha ID (and we parse it here too)
-captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(API_KEY, site_key, url), proxies=proxy).text.split('|')[1]
+captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(
+    API_KEY, site_key, url)).text.split('|')[1]
 # then we parse gresponse from 2captcha response
-recaptcha_answer = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(API_KEY, captcha_id), proxies=proxy).text
+recaptcha_answer = s.get(
+    "http://2captcha.com/res.php?key={}&action=get&id={}".format(API_KEY, captcha_id)).text
 print("solving ref captcha...")
 while 'CAPCHA_NOT_READY' in recaptcha_answer:
     sleep(5)
-    recaptcha_answer = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(API_KEY, captcha_id), proxies=proxy).text
+    recaptcha_answer = s.get(
+        "http://2captcha.com/res.php?key={}&action=get&id={}".format(API_KEY, captcha_id)).text
 recaptcha_answer = recaptcha_answer.split('|')[1]
 
 # we make the payload for the post data here, use something like mitmproxy or fiddler to see what is needed
 payload = {
     'key': 'value',
-    'gresponse': recaptcha_answer  # This is the response from 2captcha, which is needed for the post request to go through.
-    }
-
+    # This is the response from 2captcha, which is needed for the post request to go through.
+    'gresponse': recaptcha_answer
+}
 
 # then send the post request to the url
-response = s.post(url, payload, proxies=proxy)
+response = s.post(url, payload)
 
 # And that's all there is to it other than scraping data from the website, which is dynamic for every website.


### PR DESCRIPTION
Proxy parameter is used incorrectly and looks confusing. There's no real need to use proxies when you make calls to the API.